### PR TITLE
Fix: Redirect failing after payment is made

### DIFF
--- a/app/payments/paystack.php
+++ b/app/payments/paystack.php
@@ -177,7 +177,8 @@ if (defined('PAYMENT_NOTIFICATION')) {
 }else {
 
 
-    $url = fn_url("payment_notification.return?payment=paystack", BOOTSTRAP, 'current');
+    //$url = fn_url("payment_notification.return?payment=paystack", BOOTSTRAP, 'current');
+    $url = fn_url("payment_notification.return?payment=paystack");
     $currency = fn_get_secondary_currency();
     $maintotal = $order_info['total']+$order_info['payment_surcharge'];
     $mode = $processor_data['processor_params']['paystack_mode'];


### PR DESCRIPTION
Redirects were failing after payment was made because the page was redirecting to **`index.php?xxxxxxxxx`** instead of **`https://domain_name/index.php?xxxxxxxxx`**

This was fixed by changing the function
**`$url = fn_url("payment_notification.return?payment=paystack", BOOTSTRAP, 'current');`**

to

**`$url = fn_url("payment_notification.return?payment=paystack");`**